### PR TITLE
Change backup frequency and location

### DIFF
--- a/gitlab-rc.yaml
+++ b/gitlab-rc.yaml
@@ -190,7 +190,7 @@ resources:
       server: { get_resource: gitlab_server }
       BackupConfigurationName:
         str_replace:
-          template: stack Weekly Backup
+          template: stack Daily Backup
           params:
             stack: { get_param: "OS::stack_name" }
       Inclusions:

--- a/gitlab-rc.yaml
+++ b/gitlab-rc.yaml
@@ -194,9 +194,7 @@ resources:
           params:
             stack: { get_param: "OS::stack_name" }
       Inclusions:
-      - FilePath: "/var/spool/holland"
-        FileItemType: "Folder"
-      - FilePath: "/var/www/"
+      - FilePath: "/var/opt/gitlab/backups/"
         FileItemType: "Folder"
       NotifyFailure: true
       NotifyRecipients: { get_param: gitlab_email }
@@ -205,8 +203,8 @@ resources:
       StartTimeHour: 1
       StartTimeMinute: 0
       HourInterval: null
-      DayOfWeekId: 0
-      Frequency: "Weekly"
+      DayOfWeekId: null
+      Frequency: "Daily"
       VersionRetention: 30
 outputs:
   ssh_private_key:


### PR DESCRIPTION
Gitlab does not use /var/spoo/holland or /var/www from our templates, so there is no reason to bacl these up.. You already setup a cronjob to run the backup creator daily, so I've updated the template to match - stack bf37fde8-32b2-40b1-9cc3-5bffc798468a built for test